### PR TITLE
Dialog into game container

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,19 +47,19 @@
     "@jsenv/server": "3.0.0",
     "react": "16.13.1",
     "react-dom": "16.13.1",
-    "systemjs": "6.4.0"
+    "systemjs": "6.4.1"
   },
   "devDependencies": {
     "@babel/plugin-transform-react-jsx": "7.10.4",
     "@jsenv/assert": "2.2.1",
     "@jsenv/codecov-upload": "3.4.1",
-    "@jsenv/core": "14.0.0",
+    "@jsenv/core": "14.2.1",
     "@jsenv/eslint-config": "12.5.0",
     "@jsenv/file-size-impact": "4.1.0",
     "@jsenv/lighthouse-score-impact": "2.3.2",
     "@jsenv/node-module-import-map": "12.0.1",
     "@jsenv/prettier-check-project": "5.6.1",
-    "eslint": "7.5.0",
+    "eslint": "7.6.0",
     "playwright-chromium": "1.2.1",
     "prettier": "2.0.5"
   }

--- a/src/dialog/Dialog.jsx
+++ b/src/dialog/Dialog.jsx
@@ -9,8 +9,21 @@ export const Dialog = (props) => {
     <>
       <DialogHeadStyle />
       <DialogBase
-        overlayProps={{
-          className: "dialog--overlay",
+        backdropProps={{
+          className: "dialog--backdrop",
+        }}
+        style={{
+          top: "10%",
+          left: "6%",
+          right: "6%",
+          bottom: "8%",
+          height: "auto",
+          width: "auto",
+          padding: "0",
+          border: "none",
+          background: "none",
+          maxWidth: "620px",
+          margin: "0 auto",
         }}
         className={"dialog"}
         {...props}

--- a/src/dialog/Dialog.jsx
+++ b/src/dialog/Dialog.jsx
@@ -1,5 +1,6 @@
 import React from "react"
 
+import { useDialogContainerNode } from "src/game.store.js"
 import { HeadStyle } from "src/generic/HeadStyle.js"
 
 import { DialogBase } from "./DialogBase.jsx"
@@ -9,6 +10,7 @@ export const Dialog = (props) => {
     <>
       <DialogHeadStyle />
       <DialogBase
+        container={useDialogContainerNode()}
         backdropProps={{
           className: "dialog--backdrop",
         }}

--- a/src/dialog/DialogBase.jsx
+++ b/src/dialog/DialogBase.jsx
@@ -14,7 +14,7 @@ https://fr.reactjs.org/docs/portals.html
 */
 
 const DIALOG_STYLE = {
-  position: "fixed",
+  position: "absolute",
   top: "5%",
   left: "0",
   right: "0",
@@ -42,6 +42,7 @@ const BACKDROP_STYLE = {
 }
 
 export const DialogBase = ({
+  container = document.body,
   children,
   isOpen,
   // closeMethod can be "visibility-hidden", "hidden-attribute", "dom-remove"
@@ -61,6 +62,7 @@ export const DialogBase = ({
   backdropProps = {},
   ...rest
 }) => {
+  if (!container) return null
   const [dialogElement, setDialogElement] = React.useState(null)
 
   const isInsideDocument = Boolean(dialogElement)
@@ -234,7 +236,7 @@ export const DialogBase = ({
         {children}
       </div>
     </>,
-    document.body,
+    container,
   )
 }
 

--- a/src/dialog/dialog.css
+++ b/src/dialog/dialog.css
@@ -1,3 +1,11 @@
+.dialog--backdrop {
+  z-index: 1;
+}
+
+.dialog {
+  z-index: 1;
+}
+
 .dialog .border {
   background-image: url("./wood.png");
   position: absolute;

--- a/src/dialog/scenarios/dialog-click-outside.scenario.html
+++ b/src/dialog/scenarios/dialog-click-outside.scenario.html
@@ -20,7 +20,7 @@ This scenario is to test
     <script type="module">
       import React from "react"
       import ReactDOM from "react-dom"
-      import { Dialog } from "../Dialog.jsx"
+      import { DialogBase } from "../DialogBase.jsx"
 
       const App = () => {
         const [dialogIsOpen, setDialogIsOpen] = React.useState(false)
@@ -53,7 +53,7 @@ This scenario is to test
                   : "dialog not opened "
               }
             </span>
-            <Dialog
+            <DialogBase
               isOpen={dialogIsOpen}
               onRequestClose={closeDialog}
               trapFocus={false}
@@ -67,7 +67,7 @@ This scenario is to test
             >
               Hello world
               <button onClick={closeDialog}>Close</button>
-            </Dialog>
+            </DialogBase>
           </>
         )
       }

--- a/src/dialog/scenarios/dialog-focus-escape.scenario.html
+++ b/src/dialog/scenarios/dialog-focus-escape.scenario.html
@@ -20,7 +20,7 @@ focusable elements
     <script type="module">
       import React from "react"
       import ReactDOM from "react-dom"
-      import { Dialog } from "../Dialog.jsx"
+      import { DialogBase } from "../DialogBase.jsx"
 
       const App = () => {
         const [dialogIsOpen, setDialogIsOpen] = React.useState(false)
@@ -42,9 +42,9 @@ focusable elements
             >
               Open dialog
             </button>
-            <Dialog isOpen={dialogIsOpen} onRequestClose={closeDialog} trapFocus={true}>
+            <DialogBase isOpen={dialogIsOpen} onRequestClose={closeDialog} trapFocus={true}>
               Hello world
-            </Dialog>
+            </DialogBase>
           </>
         )
       }

--- a/src/dialog/scenarios/dialog-focus-mousedown.scenario.html
+++ b/src/dialog/scenarios/dialog-focus-mousedown.scenario.html
@@ -26,7 +26,7 @@ This scenario is to test
     <script type="module">
       import React from "react"
       import ReactDOM from "react-dom"
-      import { Dialog } from "../Dialog.jsx"
+      import { DialogBase } from "../DialogBase.jsx"
 
       const App = () => {
         const [dialogIsOpen, setDialogIsOpen] = React.useState(false)
@@ -48,10 +48,10 @@ This scenario is to test
             >
               Open dialog
             </button>
-            <Dialog isOpen={dialogIsOpen} onRequestClose={closeDialog} trapFocus={false}>
+            <DialogBase isOpen={dialogIsOpen} onRequestClose={closeDialog} trapFocus={false}>
               Hello world
               <button onClick={closeDialog}>Close</button>
-            </Dialog>
+            </DialogBase>
           </>
         )
       }

--- a/src/dialog/scenarios/dialog-open-button.scenario.html
+++ b/src/dialog/scenarios/dialog-open-button.scenario.html
@@ -28,7 +28,7 @@ This scenario is meant to test that
     <script type="module">
       import React from "react"
       import ReactDOM from "react-dom"
-      import { Dialog } from "../Dialog.jsx"
+      import { DialogBase } from "../DialogBase.jsx"
 
       const App = () => {
         const [dialogIsOpen, setDialogIsOpen] = React.useState(false)
@@ -50,10 +50,10 @@ This scenario is meant to test that
             >
               Open dialog
             </button>
-            <Dialog isOpen={dialogIsOpen} onRequestClose={closeDialog}>
+            <DialogBase isOpen={dialogIsOpen} onRequestClose={closeDialog}>
               Hello world
               <button onClick={closeDialog}>Close</button>
-            </Dialog>
+            </DialogBase>
           </>
         )
       }

--- a/src/dialog/scenarios/dialog-opened.scenario.html
+++ b/src/dialog/scenarios/dialog-opened.scenario.html
@@ -25,7 +25,7 @@ This scenario is to test
     <script type="module">
       import React from "react"
       import ReactDOM from "react-dom"
-      import { Dialog } from "../Dialog.jsx"
+      import { DialogBase } from "../DialogBase.jsx"
 
       const App = () => {
         const [dialogIsOpen, setDialogIsOpen] = React.useState(true)
@@ -47,7 +47,7 @@ This scenario is to test
             >
               Open dialog
             </button>
-            <Dialog
+            <DialogBase
               isOpen={dialogIsOpen}
               onRequestClose={closeDialog}
               trapFocus={false}
@@ -55,7 +55,7 @@ This scenario is to test
             >
               Hello world
               <button onClick={closeDialog}>Close</button>
-            </Dialog>
+            </DialogBase>
           </>
         )
       }

--- a/src/dialog/scroll-trap.js
+++ b/src/dialog/scroll-trap.js
@@ -1,4 +1,4 @@
-import { getStyleValue } from "src/dom/dom.js"
+import { getStyleValue, isDocumentElement } from "src/dom/dom.js"
 
 export const trapScrollInside = (element) => {
   const elementsToScrollLock = []
@@ -175,7 +175,11 @@ const findScrollableParent = (element) => {
   const position = getStyleValue(element, "position")
   let parent = element.parentNode
   while (parent) {
+    if (isDocumentElement(parent)) {
+      return null
+    }
     if (position === "absolute" && getStyleValue(parent, "position") === "static") {
+      parent = parent.parentNode
       continue
     }
     if (isScrollable(parent)) {

--- a/src/game.component.js
+++ b/src/game.component.js
@@ -1,6 +1,7 @@
 /* eslint-disable import/max-dependencies */
 import React from "react"
 
+import { useDialogContainerCallback } from "src/game.store.js"
 import { HeadStyle } from "src/generic/HeadStyle.js"
 import { GameEffects } from "src/game.effects.js"
 import { PreloadImages } from "src/PreloadImages.jsx"
@@ -25,9 +26,11 @@ export const Game = () => {
 
   There is no real need for useMemo here: it's kept as an example.
   */
+  const dialogContainerCallback = useDialogContainerCallback()
+
   return useMemo(() => (
     <div id="game-container">
-      <div id="mille-sabord-container">
+      <div id="mille-sabord-container" ref={dialogContainerCallback}>
         <HeadStyle href="/mille-sabord.css" />
         <GameEffects />
         <PreloadImages />

--- a/src/game.store.js
+++ b/src/game.store.js
@@ -69,10 +69,13 @@ export const createGameAction = gameStateStore.createAction
 
 export const gameNodeStore = createDOMNodeStore({
   "rolled-area": null,
+  "dialog-container": null,
   ...DICES.reduce((obj, dice) => {
     return { ...obj, [`dice-${dice.id}`]: null }
   }, {}),
 })
+export const useDialogContainerNode = () => gameNodeStore.useDOMNode("dialog-container")
+export const useDialogContainerCallback = () => gameNodeStore.useDOMNodeCallback("dialog-container")
 export const useRolledAreaNode = () => gameNodeStore.useDOMNode("rolled-area")
 export const useRolledAreaNodeCallback = () => gameNodeStore.useDOMNodeCallback("rolled-area")
 export const useDiceNode = (id) => gameNodeStore.useDOMNode(`dice-${id}`)


### PR DESCRIPTION
- rename overlay into backdrop
- backdrop is now the prev sibling of dialog (instead of being the parent)
- put specific styles in Dialog.jsx or css
- fix infinite loop in scroll trp
- fix onFocusOut when focus leaves document

Fix #50 